### PR TITLE
Updated templates to support Neo 1.6.0

### DIFF
--- a/docs/dev/change_notes/PR_71_imp-updates.md
+++ b/docs/dev/change_notes/PR_71_imp-updates.md
@@ -1,0 +1,33 @@
+<!-- markdownlint-disable MD041 -->
+
+# Change Note
+
+This is an example change note.
+
+## New 🚀
+
+- Added `command` command. A nice example command
+
+## Improvements 💪
+
+- Added `example` flag to `command` for more customizability
+
+## Fixes 🐞
+
+- Fixed an issue in `command` that caused crashes if the input was empty
+
+## Deprecated ⛔
+
+- Deprecated `old command` in favor of `new command`
+
+## Removed ❌
+
+- Removed `command`
+
+# Internal Change Note
+
+This is an example internal change note
+
+## Changes 🛠️
+
+- Changed some internal logic

--- a/docs/dev/change_notes/PR_71_imp-updates.md
+++ b/docs/dev/change_notes/PR_71_imp-updates.md
@@ -2,32 +2,21 @@
 
 # Change Note
 
-This is an example change note.
-
-## New 🚀
-
-- Added `command` command. A nice example command
+Template updates for Neo 1.6.0 compatibility and template builder improvements.
 
 ## Improvements 💪
 
-- Added `example` flag to `command` for more customizability
-
-## Fixes 🐞
-
-- Fixed an issue in `command` that caused crashes if the input was empty
-
-## Deprecated ⛔
-
-- Deprecated `old command` in favor of `new command`
-
-## Removed ❌
-
-- Removed `command`
+- **Sidebar template**: Updated to use Neo 1.6.0 API by removing deprecated `activeItem` and `setActiveItem()` usage
+  - Removed `MyObserver` router observer class
+  - Updated sidebar layout to use route-based active state detection via `router.currentPath`
+  - Changed `buildSidebarButton` to use `routePrefix` parameter for determining active state
+  - Sidebar buttons now automatically determine active state based on current route path
 
 # Internal Change Note
 
-This is an example internal change note
-
 ## Changes 🛠️
 
-- Changed some internal logic
+- Updated `template_builder.dart` to escape `${}` sequences when reading template files: `content.replaceAll(r'${', r'\${')`
+- Removed `MyObserver` class from sidebar template router file
+- Updated sidebar layout to use `router.currentPath.toLowerCase()` and route prefix matching instead of local state management
+- Removed unused imports (`flutter_hooks`, `hooks_riverpod` from router observer) from sidebar template files

--- a/lib/templates/sidebar/files/lib/main.dart
+++ b/lib/templates/sidebar/files/lib/main.dart
@@ -25,7 +25,7 @@ class MyApp extends ConsumerWidget {
     return NeoApp(
       title: "{{_PROJECT_NAME_}}",
       defaultThemeMode: NeoThemeMode.system,
-      routerConfig: neoRouter.config(navigatorObservers: () => [MyObserver(ref)]),
+      routerConfig: neoRouter.config(),
     );
   }
 }

--- a/lib/templates/sidebar/files/lib/router/neo_router.dart
+++ b/lib/templates/sidebar/files/lib/router/neo_router.dart
@@ -1,7 +1,4 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter/widgets.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:neo/neo.dart';
 
 import 'neo_router.gr.dart';
 
@@ -34,32 +31,4 @@ class NeoRouter extends RootStackRouter {
           redirectTo: "/",
         ),
       ];
-}
-
-class MyObserver extends AutoRouterObserver {
-  final WidgetRef ref;
-
-  MyObserver(this.ref);
-
-  String _formatRouteName(String routeName) => routeName.replaceAll('Route', '').replaceAll(RegExp(r'(?=[A-Z])'), ' ').trim();
-
-  @override
-  void didPush(Route route, Route? previousRoute) {
-    if (route.settings.name != null) {
-      Future.microtask(() {
-        ref.read(neoCurrentSidebarStatesProvider.notifier).setActiveItem(_formatRouteName(route.settings.name!));
-      });
-    }
-    super.didPush(route, previousRoute);
-  }
-
-  @override
-  void didPop(Route route, Route? previousRoute) {
-    if (previousRoute?.settings.name != null) {
-      Future.microtask(() {
-        ref.read(neoCurrentSidebarStatesProvider.notifier).setActiveItem(_formatRouteName(previousRoute!.settings.name!));
-      });
-    }
-    super.didPop(route, previousRoute);
-  }
 }

--- a/lib/templates/sidebar/files/lib/screens/sidebar_layout.dart
+++ b/lib/templates/sidebar/files/lib/screens/sidebar_layout.dart
@@ -1,6 +1,5 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:neo/neo.dart';
@@ -18,22 +17,24 @@ class SidebarLayout extends HookConsumerWidget {
     final router = AutoRouter.of(context);
 
     final neoSidebarCurrentStates = ref.watch(neoCurrentSidebarStatesProvider);
-    final activeItem = useState("Dashboard");
+    final currentRoute = router.currentPath.toLowerCase();
 
-    Widget buildSidebarButton(
-      String text, {
+    Widget buildSidebarButton({
+      required String text,
+      required String routePrefix,
+      required Function() onPressed,
       PhosphorIconData Function(PhosphorIconsStyle)? icon,
       String? badgeText,
       Color? badgeColor,
-      Function()? onPressed,
     }) {
+      final isActive = currentRoute.startsWith("/${routePrefix.toLowerCase()}");
       return NeoSidebarButton(
         label: text,
-        isActive: activeItem.value == text,
+        isActive: isActive,
         icon: icon,
         badgeText: badgeText,
         badgeColor: badgeColor,
-        onPressed: onPressed ?? () {},
+        onPressed: onPressed,
       );
     }
 
@@ -72,26 +73,22 @@ class SidebarLayout extends HookConsumerWidget {
                 child: Column(
                   children: [
                     buildSidebarButton(
-                      "Dashboard",
+                      text: "Dashboard",
+                      routePrefix: "dashboard",
                       icon: PhosphorIcons.squaresFour,
                       onPressed: () {
-                        if (activeItem.value != "Dashboard") {
-                          NeoHaptics.light();
-                          activeItem.value = "Dashboard";
-                          router.push(const DashboardRoute());
-                        }
+                        NeoHaptics.light();
+                        router.push(const DashboardRoute());
                       },
                     ),
                     Gap(theme.spacings.extraSmall),
                     buildSidebarButton(
-                      "Products",
+                      text: "Products",
+                      routePrefix: "products",
                       icon: PhosphorIcons.tag,
                       onPressed: () {
-                        if (activeItem.value != "Products") {
-                          NeoHaptics.light();
-                          activeItem.value = "Products";
-                          router.push(const ProductsRoute());
-                        }
+                        NeoHaptics.light();
+                        router.push(const ProductsRoute());
                       },
                     ),
                   ],
@@ -102,14 +99,12 @@ class SidebarLayout extends HookConsumerWidget {
         ),
         Gap(theme.spacings.extraSmall),
         buildSidebarButton(
-          "Settings",
+          text: "Settings",
+          routePrefix: "settings",
           icon: PhosphorIcons.gear,
           onPressed: () {
-            if (activeItem.value != "Settings") {
-              NeoHaptics.light();
-              activeItem.value = "Settings";
-              router.push(const SettingsRoute());
-            }
+            NeoHaptics.light();
+            router.push(const SettingsRoute());
           },
         ),
       ],

--- a/lib/templates/template_builder.dart
+++ b/lib/templates/template_builder.dart
@@ -80,9 +80,11 @@ class TemplateBuilder implements Builder {
       // Always normalize paths to use forward slashes
       final normalizedPath = path.relative(file.path, from: filesDir).replaceAll(r'\', '/');
       final content = await buildStep.readAsString(file);
+      // Escape ${} sequences to prevent Dart from trying to interpolate them in const context
+      final escapedContent = content.replaceAll(r'${', r'\${');
 
       buffer.writeln("    '$normalizedPath': '''");
-      buffer.writeln(content);
+      buffer.writeln(escapedContent);
       buffer.writeln("''',");
     }
     buffer.writeln('  };');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
+      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
       url: "https://pub.dev"
     source: hosted
-    version: "91.0.0"
+    version: "92.0.0"
   analyzer:
     dependency: "direct dev"
     description:
       name: analyzer
-      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
+      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.1"
+    version: "9.0.0"
   args:
     dependency: "direct main"
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: "direct main"
     description:
       name: build
-      sha256: dfb67ccc9a78c642193e0c2d94cb9e48c2c818b3178a86097d644acdcde6a8d9
+      sha256: c1668065e9ba04752570ad7e038288559d1e2ca5c6d0131c0f5f55e39e777413
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.3"
   build_config:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "7b5b569f3df370590a85029148d6fc66c7d0201fc6f1847c07dd85d365ae9fcd"
+      sha256: "110c56ef29b5eb367b4d17fc79375fa8c18a6cd7acd92c05bb3986c17a079057"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.3"
+    version: "2.10.4"
   built_collection:
     dependency: transitive
     description:
@@ -357,10 +357,10 @@ packages:
     dependency: "direct dev"
     description:
       name: source_gen
-      sha256: "9098ab86015c4f1d8af6486b547b11100e73b193e1899015033cb3e14ad20243"
+      sha256: "07b277b67e0096c45196cbddddf2d8c6ffc49342e88bf31d460ce04605ddac75"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.1"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,4 +21,4 @@ dev_dependencies:
   test: ^1.24.0
   build_runner: ^2.4.8
   source_gen: ^4.0.2
-  analyzer: ^8.4.1
+  analyzer: ^9.0.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors sidebar template to route-based active state (no observer/local state) and escapes `${}` in template builder; bumps `analyzer` dev dependency.
> 
> - **Templates — Sidebar (Neo 1.6.0 compatibility)**:
>   - Remove deprecated active state handling: delete `MyObserver`, drop `activeItem` state, and stop passing navigator observers in `main.dart` (`neoRouter.config()`).
>   - Use route-based active detection via `router.currentPath` and `routePrefix` in `buildSidebarButton`.
>   - Simplify button handlers to push routes directly; unused imports removed.
> - **Template Builder**:
>   - Escape `${}` sequences when embedding template file contents (`content.replaceAll(r'${', r'\${')`).
> - **Dev Tooling**:
>   - Bump `analyzer` to `^9.0.0` in `pubspec.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1c3616ddfbbfb071fca72feed3c6556c59b5615. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->